### PR TITLE
fix(backend): change jest --watch to --watchAll

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,7 @@
     "start:prod": "node dist/main",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
-    "test:watch": "jest --watch",
+    "test:watch": "jest --watchAll",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json --runInBand"


### PR DESCRIPTION
Change `npm run test:watch` to use `--watchAll` so that the command can function on the docker containers

Fix #66 