### PR TITLE
feat(frontend): implement lazy loading for profiles images

### DIFF
--- a/frontend/src/assets/images/abouchau-lazy.jpg
+++ b/frontend/src/assets/images/abouchau-lazy.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a4159fa8bd04e30ad6daf5f78aa091d7db4c6b430e91d974d72f58cc37c8320
+size 37472

--- a/frontend/src/assets/images/abouchau.jpg
+++ b/frontend/src/assets/images/abouchau.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:48c81f4b1aa2d72166edba32671df21181cd2e6987016e39d2168dcc0e5d252d
-size 326320

--- a/frontend/src/assets/images/fyusuf-a-lazy.jpg
+++ b/frontend/src/assets/images/fyusuf-a-lazy.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c265ecf3c83424287ddbb8dafb28e9e5287ff9e61f55f34827723bc8daaf3f08
+size 39256

--- a/frontend/src/assets/images/fyusuf-a.jpg
+++ b/frontend/src/assets/images/fyusuf-a.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:331e46a70f31c00c8cdf40abbf54ac816ee9ee2ce02909ea2bb0b72226958eb7
-size 325468

--- a/frontend/src/assets/images/mdesfont-lazy.jpg
+++ b/frontend/src/assets/images/mdesfont-lazy.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a7803819cdb4806db75ec5536f7cb14c78829812772ffb01b4232e22003e82ed
+size 38263

--- a/frontend/src/assets/images/mdesfont.jpg
+++ b/frontend/src/assets/images/mdesfont.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9704f4fae50a21dd835106447fde5973549ea333f3592883e72ecc79878a50b1
-size 301233

--- a/frontend/src/assets/images/tmorris-lazy.jpg
+++ b/frontend/src/assets/images/tmorris-lazy.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:cdca506c755367d3624aef251f09ec25e1d9080a44cb6cafbb7cf28fd603a2b0
+size 34028

--- a/frontend/src/assets/images/tmorris.jpg
+++ b/frontend/src/assets/images/tmorris.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08a44555da188785908bb73497185eaf7bb6ecc68ef2134aa981de7930bf7710
-size 216606

--- a/frontend/src/assets/images/tvideira-lazy.jpg
+++ b/frontend/src/assets/images/tvideira-lazy.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b72f01a45c810e2dec4d0ad88751e8ea172770358a5bedf48d6b63874fb897d0
+size 38586

--- a/frontend/src/assets/images/tvideira.jpg
+++ b/frontend/src/assets/images/tvideira.jpg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3ac5d41809a5e3ebba233d4ee1e45160a8195f67ea33f79792fd369f9bf0cf37
-size 285243

--- a/frontend/src/components/Team/TeamCard.vue
+++ b/frontend/src/components/Team/TeamCard.vue
@@ -4,7 +4,16 @@
       <v-card tile>
         <v-col align="center" class="mt-5">
           <v-avatar size="100">
-            <v-img :src="teamMate.picture"></v-img>
+            <v-img :src="teamMate.picture" :lazy-src="teamMate.lazyPicture">
+              <template v-slot:placeholder>
+                <v-row class="fill-height ma-0" align="center" justify="center">
+                  <v-progress-circular
+                    indeterminate
+                    color="teal"
+                  ></v-progress-circular>
+                </v-row>
+              </template>
+            </v-img>
           </v-avatar>
           <v-card-text class="text--primary">
             <div>{{ teamMate.login }}</div>
@@ -27,35 +36,40 @@ export default {
     return {
       teamMates: [
         {
-          picture: require("@/assets/images/abouchau.jpg"),
+          picture: "https://cdn.intra.42.fr/users/abouchau.jpg",
+          lazyPicture: require("@/assets/images/abouchau-lazy.jpg"),
           login: "abouchau",
           name: "Nina Bouchau",
           githubLink: "https://github.com/N-4-Nina",
           id: 1,
         },
         {
-          picture: require("@/assets/images/fyusuf-a.jpg"),
+          picture: "https://cdn.intra.42.fr/users/fyusuf-a.jpg",
+          lazyPicture: require("@/assets/images/fyusuf-a-lazy.jpg"),
           login: "fyusuf-a",
           name: "Florian Yusuf Ali",
           githubLink: "https://github.com/fyusuf-a",
           id: 2,
         },
         {
-          picture: require("@/assets/images/mdesfont.jpg"),
+          picture: "https://cdn.intra.42.fr/users/mdesfont.jpg",
+          lazyPicture: require("@/assets/images/mdesfont-lazy.jpg"),
           login: "mdesfont",
           name: "Louie Desfontaines",
           githubLink: "https://github.com/Mel-louie",
           id: 3,
         },
         {
-          picture: require("@/assets/images/tmorris.jpg"),
+          picture: "https://cdn.intra.42.fr/users/tmorris.jpg",
+          lazyPicture: require("@/assets/images/tmorris-lazy.jpg"),
           login: "tmorris",
           name: "Taylor Morris",
           githubLink: "https://github.com/tmorris42",
           id: 4,
         },
         {
-          picture: require("@/assets/images/tvideira.jpg"),
+          picture: "https://cdn.intra.42.fr/users/tvideira.jpg",
+          lazyPicture: require("@/assets/images/tvideira-lazy.jpg"),
           login: "tvideira",
           name: "Théo Videira",
           githubLink: "https://github.com/tvideira",


### PR DESCRIPTION
- used ```<v-img>``` property ```lazy-src```, to load lighter version of the images
- changed the source of the profiles pics to get them from the intra, just the lighter ones for ```lazy-src``` are in the assets
- after some tests, chosed to use ```lazy-src``` and not a new application wide component because ```<v-img>``` already have good properties to load pictures and generate effecient and nice placeholder, Vuetify is very effective