### PR TITLE
feat(memberships): check authorization to create

### DIFF
--- a/backend/src/memberships/memberships.controller.spec.ts
+++ b/backend/src/memberships/memberships.controller.spec.ts
@@ -1,4 +1,4 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, UnauthorizedException } from '@nestjs/common';
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { EntityDoesNotExistError } from 'src/errors/entityDoesNotExist';
@@ -15,16 +15,22 @@ import { User } from 'src/users/entities/user.entity';
 import { Channel } from 'src/channels/entities/channel.entity';
 import { Friendship } from 'src/relationships/entities/friendship.entity';
 import { Block } from 'src/relationships/entities/block.entity';
+import { ChannelsService } from 'src/channels/channels.service';
+import { ChannelType } from 'src/dtos/channels';
+import { Request } from 'express';
 
 describe('MembershipsController', () => {
   let controller: MembershipsController;
   let service: MembershipsService;
+  let channelsService: ChannelsService;
+  let mockRequest: Request;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [MembershipsController],
       providers: [
         MembershipsService,
+        ChannelsService,
         {
           provide: getRepositoryToken(Membership),
           useValue: jest.fn(),
@@ -50,6 +56,8 @@ describe('MembershipsController', () => {
 
     controller = module.get<MembershipsController>(MembershipsController);
     service = module.get<MembershipsService>(MembershipsService);
+    channelsService = module.get<ChannelsService>(ChannelsService);
+    mockRequest = { user: { id: 5 } } as unknown as Request;
   });
 
   it('should be defined', () => {
@@ -94,7 +102,10 @@ describe('MembershipsController', () => {
       jest
         .spyOn(service, 'create')
         .mockImplementation(async () => mockMembership);
-      const result = await controller.create(createMembershipDto);
+      const mockChannel = new Channel();
+      mockChannel.type = ChannelType.PUBLIC;
+      jest.spyOn(channelsService, 'findOne').mockResolvedValue(mockChannel);
+      const result = await controller.create(createMembershipDto, mockRequest);
       expect(result).toEqual(mockMembership);
     });
 
@@ -106,9 +117,12 @@ describe('MembershipsController', () => {
       jest.spyOn(service, 'create').mockImplementation(async () => {
         throw new EntityDoesNotExistError('error');
       });
-      expect(controller.create(createMembershipDto)).rejects.toThrow(
-        BadRequestException,
-      );
+      const mockChannel = new Channel();
+      mockChannel.type = ChannelType.PUBLIC;
+      jest.spyOn(channelsService, 'findOne').mockResolvedValue(mockChannel);
+      expect(
+        controller.create(createMembershipDto, mockRequest),
+      ).rejects.toThrow(BadRequestException);
     });
 
     it('should throw if service throws', async () => {
@@ -118,7 +132,167 @@ describe('MembershipsController', () => {
       jest.spyOn(service, 'create').mockImplementation(async () => {
         throw new Error('error');
       });
-      expect(controller.create(createMembershipDto)).rejects.toThrow(Error);
+      const mockChannel = new Channel();
+      mockChannel.type = ChannelType.PUBLIC;
+      jest.spyOn(channelsService, 'findOne').mockResolvedValue(mockChannel);
+      expect(
+        controller.create(createMembershipDto, mockRequest),
+      ).rejects.toThrow(Error);
+    });
+  });
+
+  describe('create() on PRIVATE channel', () => {
+    it('should return a ResponseMembershipDto if creator is admin', async () => {
+      const mockMembership = new Membership();
+      mockMembership.channelId = 1;
+      mockMembership.userId = 0;
+      mockMembership.role = MembershipRoleType.PARTICIPANT;
+      const createMembershipDto = new CreateMembershipDto();
+      createMembershipDto.channelId = 1;
+      createMembershipDto.userId = 0;
+      jest
+        .spyOn(service, 'create')
+        .mockImplementation(async () => mockMembership);
+      const mockChannel = new Channel();
+      mockChannel.type = ChannelType.PRIVATE;
+      jest.spyOn(channelsService, 'findOne').mockResolvedValue(mockChannel);
+      const mockCreatorMembership = new Membership();
+      mockCreatorMembership.role = MembershipRoleType.ADMIN;
+      jest.spyOn(service, 'findAll').mockResolvedValue([mockCreatorMembership]);
+      const result = await controller.create(createMembershipDto, mockRequest);
+      expect(result).toEqual(mockMembership);
+    });
+
+    it('should throw if not authorized', async () => {
+      const createMembershipDto = new CreateMembershipDto();
+      createMembershipDto.channelId = 1;
+      createMembershipDto.userId = 0;
+      createMembershipDto.role = MembershipRoleType.PARTICIPANT;
+      jest.spyOn(service, 'create').mockImplementation(async () => {
+        throw new EntityDoesNotExistError('error');
+      });
+      const mockChannel = new Channel();
+      mockChannel.type = ChannelType.PRIVATE;
+      const mockCreatorMembership = new Membership();
+      mockCreatorMembership.role = MembershipRoleType.PARTICIPANT;
+      jest.spyOn(service, 'findAll').mockResolvedValue([mockCreatorMembership]);
+      jest.spyOn(channelsService, 'findOne').mockResolvedValue(mockChannel);
+      expect(
+        controller.create(createMembershipDto, mockRequest),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('create() on PROTECTED channel', () => {
+    it('should return a ResponseMembershipDto', async () => {
+      const mockMembership = new Membership();
+      mockMembership.channelId = 1;
+      mockMembership.userId = 0;
+      mockMembership.role = MembershipRoleType.PARTICIPANT;
+      const createMembershipDto = new CreateMembershipDto();
+      createMembershipDto.channelId = 1;
+      createMembershipDto.userId = 0;
+      createMembershipDto.password = 'password';
+      jest
+        .spyOn(service, 'create')
+        .mockImplementation(async () => mockMembership);
+      const mockChannel = new Channel();
+      mockChannel.type = ChannelType.PROTECTED;
+      mockChannel.password =
+        '$2b$10$/.KrB7B.amqoVxsqLHo.YuVl1Dhfw60L9Q9N.U3csybePzXqifZeS';
+      jest.spyOn(channelsService, 'findOne').mockResolvedValue(mockChannel);
+      const result = await controller.create(createMembershipDto, mockRequest);
+      expect(result).toEqual(mockMembership);
+    });
+
+    it('should throw if not authorized', async () => {
+      const mockMembership = new Membership();
+      mockMembership.channelId = 1;
+      mockMembership.userId = 0;
+      mockMembership.role = MembershipRoleType.PARTICIPANT;
+      const createMembershipDto = new CreateMembershipDto();
+      createMembershipDto.channelId = 1;
+      createMembershipDto.userId = 0;
+      createMembershipDto.password = 'badpassword';
+      jest
+        .spyOn(service, 'create')
+        .mockImplementation(async () => mockMembership);
+      const mockChannel = new Channel();
+      mockChannel.type = ChannelType.PROTECTED;
+      mockChannel.password =
+        '$2b$10$/.KrB7B.amqoVxsqLHo.YuVl1Dhfw60L9Q9N.U3csybePzXqifZeS';
+      jest.spyOn(channelsService, 'findOne').mockResolvedValue(mockChannel);
+      expect(
+        controller.create(createMembershipDto, mockRequest),
+      ).rejects.toThrow(UnauthorizedException);
+    });
+
+    describe('create elevated memberships', () => {
+      it('should throw if role is owner', () => {
+        const mockResult = new Membership();
+        jest.spyOn(service, 'create').mockResolvedValue(mockResult);
+        const dto = new CreateMembershipDto();
+        dto.role = MembershipRoleType.OWNER;
+        dto.channelId = 5;
+        const mockCreatorMembership = new Membership();
+        mockCreatorMembership.role = MembershipRoleType.OWNER;
+        mockCreatorMembership.channelId = 5;
+        jest
+          .spyOn(service, 'findAll')
+          .mockResolvedValue([mockCreatorMembership]);
+        jest.spyOn(service, 'findOne').mockResolvedValue(mockCreatorMembership);
+        const mockChannel = new Channel();
+        mockChannel.id = 5;
+        mockChannel.type = ChannelType.PUBLIC;
+        jest.spyOn(channelsService, 'findOne').mockResolvedValue(mockChannel);
+        expect(controller.create(dto, mockRequest)).rejects.toThrow(
+          UnauthorizedException,
+        );
+      });
+
+      it('should throw if role is admin and creator is non-owner', () => {
+        const mockResult = new Membership();
+        jest.spyOn(service, 'create').mockResolvedValue(mockResult);
+        const dto = new CreateMembershipDto();
+        dto.role = MembershipRoleType.ADMIN;
+        dto.channelId = 5;
+        const mockCreatorMembership = new Membership();
+        mockCreatorMembership.role = MembershipRoleType.ADMIN;
+        mockCreatorMembership.channelId = 5;
+        jest
+          .spyOn(service, 'findAll')
+          .mockResolvedValue([mockCreatorMembership]);
+        jest.spyOn(service, 'findOne').mockResolvedValue(mockCreatorMembership);
+        const mockChannel = new Channel();
+        mockChannel.id = 5;
+        mockChannel.type = ChannelType.PUBLIC;
+        jest.spyOn(channelsService, 'findOne').mockResolvedValue(mockChannel);
+        expect(controller.create(dto, mockRequest)).rejects.toThrow(
+          UnauthorizedException,
+        );
+      });
+
+      it('should return Result if role is admin and creator is owner', () => {
+        const mockResult = new Membership();
+        jest.spyOn(service, 'create').mockResolvedValue(mockResult);
+        const dto = new CreateMembershipDto();
+        dto.role = MembershipRoleType.ADMIN;
+        dto.channelId = 5;
+        const mockCreatorMembership = new Membership();
+        mockCreatorMembership.role = MembershipRoleType.OWNER;
+        mockCreatorMembership.channelId = 5;
+        jest
+          .spyOn(service, 'findAll')
+          .mockResolvedValue([mockCreatorMembership]);
+        jest.spyOn(service, 'findOne').mockResolvedValue(mockCreatorMembership);
+        const mockChannel = new Channel();
+        mockChannel.id = 5;
+        mockChannel.type = ChannelType.PUBLIC;
+        jest.spyOn(channelsService, 'findOne').mockResolvedValue(mockChannel);
+        expect(controller.create(dto, mockRequest)).resolves.toEqual(
+          mockResult,
+        );
+      });
     });
   });
 
@@ -128,8 +302,36 @@ describe('MembershipsController', () => {
       const dto = new UpdateMembershipDto();
       dto.bannedUntil = new Date();
       jest.spyOn(service, 'update').mockImplementation(async () => mock);
-      const result = await controller.update('1', dto);
+      const result = await controller.update('1', dto, mockRequest);
       expect(result).toEqual(mock);
+    });
+
+    it('should throw when non-owner makes a user an admin', () => {
+      const dto = new UpdateMembershipDto();
+      dto.role = MembershipRoleType.ADMIN;
+      const mockCreatorMembership = new Membership();
+      mockCreatorMembership.role = MembershipRoleType.PARTICIPANT;
+      mockCreatorMembership.channelId = 5;
+      jest.spyOn(service, 'findAll').mockResolvedValue([mockCreatorMembership]);
+      jest.spyOn(service, 'findOne').mockResolvedValue(mockCreatorMembership);
+      expect(controller.update('1', dto, mockRequest)).rejects.toThrow(
+        UnauthorizedException,
+      );
+    });
+
+    it('should return a Result when owner makes a user an admin', () => {
+      const mockResult = new UpdateResult();
+      jest.spyOn(service, 'update').mockImplementation(async () => mockResult);
+      const dto = new UpdateMembershipDto();
+      dto.role = MembershipRoleType.ADMIN;
+      const mockCreatorMembership = new Membership();
+      mockCreatorMembership.role = MembershipRoleType.OWNER;
+      mockCreatorMembership.channelId = 5;
+      jest.spyOn(service, 'findAll').mockResolvedValue([mockCreatorMembership]);
+      jest.spyOn(service, 'findOne').mockResolvedValue(mockCreatorMembership);
+      expect(controller.update('1', dto, mockRequest)).resolves.toEqual(
+        mockResult,
+      );
     });
   });
 

--- a/backend/src/memberships/memberships.controller.ts
+++ b/backend/src/memberships/memberships.controller.ts
@@ -9,6 +9,8 @@ import {
   BadRequestException,
   Query,
   NotFoundException,
+  UnauthorizedException,
+  Req,
 } from '@nestjs/common';
 import { MembershipsService } from './memberships.service';
 import {
@@ -16,20 +18,112 @@ import {
   CreateMembershipDto,
   ResponseMembershipDto,
   QueryMembershipDto,
+  MembershipRoleType,
 } from '@dtos/memberships';
 import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { EntityDoesNotExistError } from 'src/errors/entityDoesNotExist';
+import { ChannelsService } from 'src/channels/channels.service';
+import { ChannelType } from 'src/channels/entities/channel.entity';
+import { EntityNotFoundError } from 'typeorm';
+import * as bcrypt from 'bcrypt';
+import { Request } from 'express';
+import { User } from 'src/users/entities/user.entity';
+
+async function userIsAdmin(
+  userId: number,
+  channelId: number,
+  membershipsService: MembershipsService,
+): Promise<boolean> {
+  const creatorMembership = await membershipsService.findAll({
+    user: userId.toString(),
+    channel: channelId.toString(),
+  });
+  if (
+    creatorMembership.length === 1 &&
+    (creatorMembership[0].role === MembershipRoleType.ADMIN ||
+      creatorMembership[0].role === MembershipRoleType.OWNER)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+async function userIsOwner(
+  userId: number,
+  channelId: number,
+  membershipsService: MembershipsService,
+): Promise<boolean> {
+  const creatorMembership = await membershipsService.findAll({
+    user: userId.toString(),
+    channel: channelId.toString(),
+  });
+  if (
+    creatorMembership.length === 1 &&
+    creatorMembership[0].role === MembershipRoleType.OWNER
+  ) {
+    return true;
+  }
+  return false;
+}
 
 @ApiBearerAuth()
 @ApiTags('channel memberships')
 @Controller('memberships')
 export class MembershipsController {
-  constructor(private readonly membershipsService: MembershipsService) {}
+  constructor(
+    private readonly membershipsService: MembershipsService,
+    private readonly channelsService: ChannelsService,
+  ) {}
 
   @Post()
   async create(
     @Body() createMembershipDto: CreateMembershipDto,
+    @Req() req: Request,
   ): Promise<ResponseMembershipDto> {
+    try {
+      let isAuthorized = false;
+      const channel = await this.channelsService.findOne(
+        createMembershipDto.channelId,
+      );
+      if (createMembershipDto.role === MembershipRoleType.OWNER) {
+        throw new UnauthorizedException();
+      }
+      if (createMembershipDto.role === MembershipRoleType.ADMIN) {
+        if (
+          !(await userIsOwner(
+            (req.user as User).id,
+            channel.id,
+            this.membershipsService,
+          ))
+        ) {
+          throw new UnauthorizedException();
+        }
+      }
+      if (channel.type === ChannelType.PRIVATE) {
+        isAuthorized = await userIsAdmin(
+          (req.user as User).id,
+          createMembershipDto.channelId,
+          this.membershipsService,
+        );
+      } else if (channel.type === ChannelType.PROTECTED) {
+        isAuthorized =
+          createMembershipDto.password &&
+          (await bcrypt.compare(
+            createMembershipDto.password,
+            channel.password,
+          ));
+      } else {
+        isAuthorized = true;
+      }
+      if (!isAuthorized) {
+        throw new UnauthorizedException();
+      }
+    } catch (error) {
+      if (error instanceof EntityNotFoundError) {
+        throw new BadRequestException('Cannot find channel');
+      }
+      throw error;
+    }
     try {
       return await this.membershipsService.create(createMembershipDto);
     } catch (error) {
@@ -59,11 +153,25 @@ export class MembershipsController {
   }
 
   @Patch(':id')
-  update(
+  async update(
     @Param('id') id: string,
     @Body() updateMembershipDto: UpdateMembershipDto,
+    @Req() req: Request,
   ) {
-    return this.membershipsService.update(+id, updateMembershipDto);
+    if (updateMembershipDto.role === MembershipRoleType.ADMIN) {
+      if (
+        !(await userIsAdmin(
+          (req.user as User).id,
+          (
+            await this.membershipsService.findOne(+id)
+          ).channelId,
+          this.membershipsService,
+        ))
+      ) {
+        throw new UnauthorizedException();
+      }
+    }
+    return await this.membershipsService.update(+id, updateMembershipDto);
   }
 
   @Delete(':id')

--- a/backend/src/memberships/memberships.module.ts
+++ b/backend/src/memberships/memberships.module.ts
@@ -5,9 +5,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { Membership } from './entities/membership.entity';
 import { User } from 'src/users/entities/user.entity';
 import { Channel } from 'src/channels/entities/channel.entity';
+import { ChannelsModule } from 'src/channels/channels.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Membership, User, Channel])],
+  imports: [
+    TypeOrmModule.forFeature([Membership, User, Channel]),
+    ChannelsModule,
+  ],
   controllers: [MembershipsController],
   providers: [MembershipsService],
   exports: [MembershipsService],

--- a/backend/src/memberships/memberships.service.ts
+++ b/backend/src/memberships/memberships.service.ts
@@ -1,6 +1,5 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { EntityDoesNotExistError } from '../errors/entityDoesNotExist';
 import { FindOptionsWhere, Repository } from 'typeorm';
 import {
   QueryMembershipDto,
@@ -25,28 +24,13 @@ export class MembershipsService {
   async create(createMembershipDto: CreateMembershipDto) {
     const membership: Membership = new Membership();
     membership.role = createMembershipDto.role;
-    membership.channel = await this.channelsRepository.findOneBy({
+    membership.channel = await this.channelsRepository.findOneByOrFail({
       id: createMembershipDto.channelId,
     });
     membership.channelId = createMembershipDto.channelId;
-    if (
-      membership.channel === undefined ||
-      membership.channel.id !== membership.channelId
-    ) {
-      throw new EntityDoesNotExistError(
-        `Channel #${createMembershipDto.channelId}`,
-      );
-    }
-    membership.user = await this.usersRepository.findOneBy({
+    membership.user = await this.usersRepository.findOneByOrFail({
       id: createMembershipDto.userId,
     });
-    membership.userId = createMembershipDto.userId;
-    if (
-      membership.user === undefined ||
-      membership.user.id !== membership.userId
-    ) {
-      throw new EntityDoesNotExistError(`User #${createMembershipDto.userId}`);
-    }
     return this.membershipRepository.save(membership);
   }
 

--- a/backend/test/membership.e2e-spec.ts
+++ b/backend/test/membership.e2e-spec.ts
@@ -96,13 +96,13 @@ describe('MembershipController (e2e)', () => {
   it('Subscribe user1 to channel', () => {
     return request(app.getHttpServer())
       .post('/memberships/')
-      .send({ channelId: 1, userId: 1, role: MembershipRoleType.OWNER })
+      .send({ channelId: 1, userId: 1, role: MembershipRoleType.PARTICIPANT })
       .expect(201);
   });
   it('Subscribe user2 to channel', () => {
     return request(app.getHttpServer())
       .post('/memberships/')
-      .send({ channelId: 1, userId: 2, role: MembershipRoleType.ADMIN })
+      .send({ channelId: 1, userId: 2, role: MembershipRoleType.PARTICIPANT })
       .expect(201);
   });
 

--- a/dtos/memberships/create-membership.dto.ts
+++ b/dtos/memberships/create-membership.dto.ts
@@ -1,5 +1,5 @@
 import { PickType } from '@nestjs/swagger';
-import { IsDate, IsOptional } from 'class-validator';
+import { IsDate, IsOptional, IsString } from 'class-validator';
 import { MembershipDto } from './membership.dto';
 
 export class CreateMembershipDto extends PickType(MembershipDto, [
@@ -14,4 +14,8 @@ export class CreateMembershipDto extends PickType(MembershipDto, [
   @IsOptional()
   @IsDate()
   bannedUntil?: Date;
+
+  @IsOptional()
+  @IsString()
+  password?: string;
 }


### PR DESCRIPTION
- prevent joining PROTECTED with bad password
- prevent joining PRIVATE if not the owner/admin
- prevent non-owners from updating users to admin
- prevent non-owners from creating admins
- prevent the creation of owners
  (that should be handled by channel creation)

   
Fix #96
Fix #155 