### PR TITLE
refactor(match)!: rename QueryMatchDto.role

### DIFF
--- a/dtos/matches/match.dto.ts
+++ b/dtos/matches/match.dto.ts
@@ -47,7 +47,7 @@ export class Match {
   awayId!: number;
 
   @ApiProperty({
-    description: 'The role of the associated user in the associated channel',
+    description: 'The current status of the match',
     type: MatchStatusType,
     enum: MatchStatusType,
     enumName: 'MatchStatusType',

--- a/dtos/matches/query-match.dto.ts
+++ b/dtos/matches/query-match.dto.ts
@@ -29,5 +29,5 @@ export class QueryMatchDto {
   })
   @IsOptional()
   @IsEnum(MatchStatusType)
-  role?: MatchStatusType;
+  status?: MatchStatusType;
 }


### PR DESCRIPTION
- Rename to status to match MatchEntity

Fix #145

BREAKING CHANGE: renames query parameter for Match