### PR TITLE
feat(frontend): add a button to add friend on profile of a user

### DIFF
--- a/frontend/src/components/Profile/AddAsFriend.vue
+++ b/frontend/src/components/Profile/AddAsFriend.vue
@@ -1,0 +1,59 @@
+<template>
+    <v-btn color="white" class="text--primary" @click="validate()">
+      Add {{ name }} as friend
+    </v-btn>
+  </template>
+  
+  <script lang="ts">
+  import { defineComponent } from 'vue';
+  import { mapGetters } from 'vuex';
+  import axios from 'axios';
+
+  export default defineComponent({
+    data: () => ({
+      valid: true,
+      name: '',
+    }),
+    props: ['user'],
+    methods: {
+      ...mapGetters(['id']),
+      validate () {
+        this.checkName(this.name);
+      },
+      async checkName (name: string) {
+        const data = {
+          sourceId: parseInt(this.id()),
+          targetId: 0
+        };
+        let response2 = await axios.get('/users/' + this.id() + '/friendships/');
+        for (let i: number = 0; i < response2.data.length; i++) {
+          console.log(response2.data[i])
+          if (response2.data[i].user.username === name) {
+            window.alert('This user is already your friend :)');
+            return;
+          }
+        };
+        let response3 = await axios.get('/users/' + this.id() + '/friendships/invites');
+        for (let i: number = 0; i < response3.data.length; i++) {
+          if (response3.data[i].user.username === name) {
+            window.alert('This user already sends you a friend request. Check your pending requests :)');
+            return;
+          }
+        };
+        await axios.post('/friendships/' + name, data)
+          .then(async response => {
+            console.log(response);
+            window.alert('Your friend request has been sent.');
+          })
+          .catch( (error) => {
+            console.error('There\'s already a friend request pending between those users');
+            window.alert('There\'s already a friend request pending between you and this user');
+          });
+      },
+    },
+    async created() {
+        this.name = this.user;
+    }
+  });
+  </script>
+  

--- a/frontend/src/components/Profile/OtherUsersProfile.vue
+++ b/frontend/src/components/Profile/OtherUsersProfile.vue
@@ -2,7 +2,11 @@
     <div>
       <v-row>
         <v-card class="pa-2 ml-15 mr-15 mt-5" width="84%" >
-          <v-card-title>{{ username }}</v-card-title>
+          <br />
+          <v-row class="ml-1">
+            <v-card-title>{{ username }}</v-card-title>
+            <add-as-friend v-if="user != userId" :user="user" />
+          </v-row>
           <v-container fluid>
             <v-row dense>
               <v-col :cols="4">
@@ -27,6 +31,7 @@
   
   <script lang="ts">
   import MyFriends from '@/components/Profile/MyFriends.vue';
+  import AddAsFriend from '@/components/Profile/AddAsFriend.vue';
   import MyAchievements from '@/components/Profile/MyAchievements.vue';
   import MyMatchHistory from '@/components/Profile/MyMatchHistory.vue';
   import MyStatistics from '@/components/Profile/MyStatistics.vue';
@@ -40,6 +45,7 @@
     username: string,
     avatar: string,
     idOther: number,
+    userId: string,
   }
   
   export default defineComponent({
@@ -49,11 +55,13 @@
         username: '',
         avatar: '',
         idOther: 0,
+        userId: '',
       };
     },
     props: ['user'],
     components: {
       "my-friends": MyFriends,
+      'add-as-friend': AddAsFriend,
       "my-achievements": MyAchievements,
       "my-matches": MyMatchHistory,
       "my-statistics": MyStatistics,
@@ -62,6 +70,8 @@
       ...mapGetters(['id']),
     },
     async created() {
+      let responseUs = await axios.get('/users/' + this.id());
+      this.userId = (responseUs.data.username);
       let response;
         try { 
           response = await axios.get(`/users/name/${this.user}`);


### PR DESCRIPTION
As said during the meeting, I added a button on the profile page of other users, to add send a friend request.

To test: 
- Go to the page of another user
- Click on "Add {{ user }} as friend"
  - If they're already your friend, no friend request is send
  - If they're not, a friend request is send
  - If there already are a pending request between us, no friend request is send
  - If you are on your profile page, the button should not appear 