### PR TITLE
feat(store): add challengeUserId to the store

### DIFF
--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -22,6 +22,7 @@ interface State {
   //socket: string,
   socket: Socket | undefined;
   cache: Cache | undefined;
+  challengedUserId: number;
 }
 
 const state: State = {
@@ -31,6 +32,7 @@ const state: State = {
   //socket: 'i am okay',
   socket: undefined, //new Socket(),//io(),
   cache: undefined,
+  challengedUserId: 0,
 };
 
 interface Mutation {
@@ -67,6 +69,10 @@ export default createStore({
     id: (state) => state.user.id,
     token: (state) => state.token,
     socket: (state) => state.socket,
+    challengeUserId: (state) => {
+      if (!state.challengedUserId) return 0;
+      else return state.challengedUserId;
+    },
   },
   mutations: {
     login(state, { id, token }: LoginUserDto) {
@@ -129,6 +135,12 @@ export default createStore({
           context.state.avatar = await fetchAvatar(+context.state.user.id);
         }
       }
+    },
+    challengeUser(context, userId: number) {
+      context.state.challengedUserId = userId;
+    },
+    removeChallenge(context) {
+      context.state.challengedUserId = 0;
     },
   },
   modules: {},


### PR DESCRIPTION
This adds the challengeUserId variable to the store so that the ChatView can set a user to challenge before redirecting to the GameView where the challenge will be issued.

## Usage
To see if there is a user to challenge:
`this.$store.getters.challengeUserId`

To update the id to be challenged:
`this.$store.dispatch('challengeUser', ID_TO_CHALLENGE);`

To remove the challenged user id:
`this.$store.dispatch('removeChallenge');`

If `this.$store.getters.challengeUserId` is `0` it means that there is no challenge to be issued

