### PR TITLE
feat(chat) allow owner to change password

### DIFF
--- a/frontend/src/components/Chat/ChannelPasswordDialog.vue
+++ b/frontend/src/components/Chat/ChannelPasswordDialog.vue
@@ -1,0 +1,90 @@
+<template>
+  <v-dialog v-model="changingLocal">
+    <v-card v-if="selectedChannel !== undefined">
+      <v-card-title>
+        Change/Set password for <u>{{ selectedChannel.name }}</u
+        ><br />
+        (Leave blank to make this channel public)</v-card-title
+      >
+
+      <v-card-text>
+        <v-text-field v-model="password" label="Password"></v-text-field>
+      </v-card-text>
+
+      <v-card-actions>
+        <v-btn color="red" text @click="resetDialog"> Cancel </v-btn>
+        <v-btn color="success" text @click="setPassword"> Confirm </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import axios from 'axios';
+import { defineComponent } from 'vue';
+import { ChannelDto } from '@/common/dto/channel.dto';
+import { ChannelType, UpdateChannelDto } from '@dtos/channels';
+
+interface DataReturnType {
+  password: string;
+}
+
+export default defineComponent({
+  props: {
+    selectedChannel: {
+      type: Object as () => ChannelDto,
+      required: false,
+    },
+    modelValue: {
+      type: Boolean,
+      required: true,
+    },
+  },
+  data(): DataReturnType {
+    return {
+      password: '',
+    };
+  },
+  methods: {
+    async handleInvite(userId: number) {
+      this.$emit('chat-invite-user', userId);
+      this.resetDialog();
+    },
+    resetDialog() {
+      this.password = '';
+      this.$emit('update:modelValue', false);
+    },
+    setPassword() {
+      if (!this.selectedChannel) return;
+      let data: UpdateChannelDto = {
+        password: this.password,
+        type: ChannelType.PROTECTED,
+      };
+      if (this.password.length === 0) {
+        data = {
+          type: ChannelType.PUBLIC,
+        };
+      }
+      axios
+        .patch('/channels/' + this.selectedChannel?.id, data)
+        .then(() => {
+          window.alert('Successfully updated password!');
+        })
+        .catch(() => {
+          window.alert('Could not update password!');
+        });
+      this.resetDialog();
+    },
+  },
+  computed: {
+    changingLocal: {
+      get(): boolean {
+        return this.modelValue;
+      },
+      set(value: boolean) {
+        this.$emit('update:modelValue', value);
+      },
+    },
+  },
+});
+</script>

--- a/frontend/src/components/Chat/ChatWindow.vue
+++ b/frontend/src/components/Chat/ChatWindow.vue
@@ -11,6 +11,7 @@
             :membership="membership"
             @chat-leave-channel="handleLeaveChannelEvent"
             @chat-invite-channel="$emit('chat-invite-channel')"
+            @chat-change-password="$emit('chat-change-password')"
           ></chat-window-menu>
         </v-col>
       </v-row>

--- a/frontend/src/views/ChatView.vue
+++ b/frontend/src/views/ChatView.vue
@@ -8,6 +8,12 @@
           @chat-invite-user="handleUserInvite"
         >
         </channel-invite-dialog>
+        <channel-password-dialog
+          v-model="changePass"
+          :selectedChannel="selectedChannel"
+          @chat-invite-user="handleUserInvite"
+        >
+        </channel-password-dialog>
         <chat-window
           v-if="selectedChannel"
           :channel="selectedChannel"
@@ -19,6 +25,7 @@
           @chat-leave-channel="handleLeaveChannelEvent"
           @chat-message-menu-selection="handleChatMessageMenuSelection"
           @chat-invite-channel="inviting = true"
+          @chat-change-password="changePass = true"
         ></chat-window>
       </v-col>
       <v-col cols="12" md="2">
@@ -53,6 +60,7 @@ import { UserDto } from '@/common/dto/user.dto';
 import { ChannelType, JoinChannelDto } from '@dtos/channels';
 import { ListBlockDto } from '@dtos/blocks';
 import { MembershipRoleType } from '@dtos/memberships';
+import ChannelPasswordDialogVue from '@/components/Chat/ChannelPasswordDialog.vue';
 interface MenuSelectionEvent {
   option: string;
   target: string;
@@ -72,6 +80,7 @@ interface DataReturnType {
   memberships: Array<MembershipDto>;
   blocks: Array<number | undefined>;
   inviting: boolean;
+  changePass: boolean;
 }
 export default defineComponent({
   data(): DataReturnType {
@@ -94,12 +103,14 @@ export default defineComponent({
       memberships: [],
       blocks: [],
       inviting: false,
+      changePass: false,
     };
   },
   components: {
     'channel-list': ChannelList,
     'chat-window': ChatWindow,
     'channel-invite-dialog': ChannelInviteDialog,
+    'channel-password-dialog': ChannelPasswordDialogVue,
   },
   methods: {
     async createChannel(channelObject: CreateChannelDto): Promise<number> {


### PR DESCRIPTION
Owner can now change/set/unset the password from the channel settings by selecting "Set or Change password"

- If a channel is PUBLIC/PRIVATE, adding a password will make it PROTECTED with the new password
- If a channel is already PROTECTED, adding a password will change the password
- If an empty password is submitted, the channel will become PUBLIC no matter what type(s) it has been before

Fix #298