### PR TITLE
Handle warning and errors in frontend

### DIFF
--- a/frontend/src/components/Profile/OtherUsersProfile.vue
+++ b/frontend/src/components/Profile/OtherUsersProfile.vue
@@ -46,6 +46,7 @@
     avatar: string,
     idOther: number,
     userId: string,
+    count: number,
   }
   
   export default defineComponent({
@@ -56,6 +57,7 @@
         avatar: '',
         idOther: 0,
         userId: '',
+        count: 0,
       };
     },
     props: ['user'],
@@ -69,6 +71,11 @@
     methods: {
       ...mapGetters(['id']),
     },
+    errorCaptured: function(err: any) {
+      console.error('Caught error:', err.message, 'the user doesn\'t exist');
+      ++this.count;
+      return false;
+    },
     async created() {
       let responseUs = await axios.get('/users/' + this.id());
       this.userId = (responseUs.data.username);
@@ -78,7 +85,8 @@
         } catch {
           this.$router.push('/404');
           return;
-      }
+        }
+      
         this.idOther = response.data.id;
         const newUser: UserDto = response.data;
         this.users.set(this.idOther, newUser);


### PR DESCRIPTION
Few points for this PR:
- Every exceptions seem to be in a try... catch in front;
- Some 500 are always there, but will be corrected from the backend, in a future PR;
- I catch and handle the warnings which displayed in ```/profile/:username``` when the username doesn't exist (<- to test to see if it's done correctly)
- Important point we (normally) haven't any un-handled warning or error in frontend, except for this one:
  - On firefox: ```Keyframe property value “” is invalid according to the syntax for “transform”.``` on some vuetify 3 componants. It doesn't happen with Chrome. The team which develops Vuetify is aware of the issue, and, as it comes from firefox, will not fix it. More info: https://github.com/vuetifyjs/vuetify/issues/15696 