### PR TITLE
fix(frontend): last case when friend request shouldn't be send

### DIFF
--- a/frontend/src/components/Profile/AddAsFriend.vue
+++ b/frontend/src/components/Profile/AddAsFriend.vue
@@ -41,6 +41,15 @@
             return;
           }
         };
+        let idBlockU = await axios.get('/users/name/' + name);
+        let me = await axios.get('/users/me')
+        let responseUBlocked = await axios.get('/users/' + idBlockU.data.id + '/blocks/');
+        for (let i: number = 0; i < responseUBlocked.data.length; i++) {
+          if (responseUBlocked.data[i].user.username === me.data.username) {
+            window.alert('You are blocked by this user.');
+            return;
+          }
+        };
         let response3 = await axios.get('/users/' + this.id() + '/friendships/invites');
         for (let i: number = 0; i < response3.data.length; i++) {
           if (response3.data[i].user.username === name) {

--- a/frontend/src/components/Profile/AddFriend.vue
+++ b/frontend/src/components/Profile/AddFriend.vue
@@ -78,13 +78,21 @@ export default defineComponent({
       };
       let responseBlocked = await axios.get('/users/' + this.id() + '/blocks/');
         for (let i: number = 0; i < responseBlocked.data.length; i++) {
-          console.log(responseBlocked.data[i])
           if (responseBlocked.data[i].user.username === name) {
             window.alert('This user is blocked. Unblocked them first.');
             return;
           }
         };
-      await axios.post('/friendships/' + name, data)
+        let idBlockU = await axios.get('/users/name/' + name);
+        let me = await axios.get('/users/me')
+        let responseUBlocked = await axios.get('/users/' + idBlockU.data.id + '/blocks/');
+        for (let i: number = 0; i < responseUBlocked.data.length; i++) {
+          if (responseUBlocked.data[i].user.username === me.data.username) {
+            window.alert('You are blocked by this user.');
+            return;
+          }
+        };
+        await axios.post('/friendships/' + name, data)
         .then(async response => {
           console.log(response);
           let response2 = await axios.get('/users/' + this.id() + '/friendships/invites');
@@ -97,7 +105,7 @@ export default defineComponent({
           window.alert('Your friend request has been sent.');
         })
         .catch( (error) => {
-          console.log(error.response.status);
+          console.error(error.response.status);
           this.nameDoesNotExist = error.response.status;
         });
         if (this.nameDoesNotExist === 0) { this.dialog = false; };


### PR DESCRIPTION
There was one last case where friend requests should not be sent that was not processed, when you are blocked by a user.
It's fix. Now, if you are blocked by someone, you can't send them a friend request.