### PR TITLE
fix(frontend): fix the error in resize, when canvas is null

### DIFF
--- a/frontend/src/components/Game/GameWindow.vue
+++ b/frontend/src/components/Game/GameWindow.vue
@@ -175,21 +175,23 @@ export default defineComponent({
     },
 	  resize() {
 		  const canvas = document.getElementById('responsive-canvas') as HTMLCanvasElement;
-		  const canvasRatio = canvas.height / canvas.width;
-		  const windowRatio = window.innerHeight / window.innerWidth;
-		  let width: string | number;
-		  let height: string | number;
-      
-		  if (windowRatio < canvasRatio ) {
-		  	height = window.innerHeight - 64;
-		  	width = height / canvasRatio;
-		  }
-      else {
-		  	width = window.innerWidth;
-		  	height = width * canvasRatio;
-		  }
-		  canvas.style.width = width + 'px';
-		  canvas.style.height = height + 'px';
+      if (canvas != null) { 
+		    const canvasRatio = canvas.height / canvas.width;
+		    const windowRatio = window.innerHeight / window.innerWidth;
+		    let width: string | number;
+		    let height: string | number;
+
+		    if (windowRatio < canvasRatio ) {
+		    	height = window.innerHeight - 64;
+		    	width = height / canvasRatio;
+		    }
+        else {
+		    	width = window.innerWidth;
+		    	height = width * canvasRatio;
+		    }
+		    canvas.style.width = width + 'px';
+		    canvas.style.height = height + 'px';
+    }
 		},
 		spectateGame(gameId: number) {
       console.log("gameId to spectate: " + gameId)


### PR DESCRIPTION
@tvideira found this error when played the game:
```
Uncaught TypeError: canvas is null
    resize GameWindow.vue:178
GameWindow.vue:178:24
    resize GameWindow.vue:178
    resize self-hosted:1115
```
I never had it, can't reproduce. So I did this fix but can't test it. That's why it is in code-review. If someone can see if it is a relevant fix?