### PR TITLE
fix(backend): recreate /users/username in users controller

### DIFF
--- a/backend/src/users/users.controller.ts
+++ b/backend/src/users/users.controller.ts
@@ -107,6 +107,21 @@ export class UsersController {
     return await this.usersService.findOne(+id);
   }
 
+  @ApiBearerAuth()
+  @Get('/name/:username')
+  @ApiResponse({ status: 404, description: 'Record not found' })
+  async findOneByUsername(
+    @Param('username') username: string,
+  ): Promise<ResponseUserDto> {
+    try {
+      return await this.usersService.findByName(username);
+    } catch (error) {
+      if (error instanceof EntityNotFoundError) {
+        throw new HttpException(error.message, HttpStatus.NOT_FOUND);
+      }
+    }
+  }
+
   @Delete(':id')
   async remove(
     @AuthUser() user: User,

--- a/frontend/src/components/Profile/OtherUsersProfile.vue
+++ b/frontend/src/components/Profile/OtherUsersProfile.vue
@@ -80,12 +80,12 @@
       let responseUs = await axios.get('/users/' + this.id());
       this.userId = (responseUs.data.username);
       let response;
-        try { 
-          response = await axios.get(`/users/name/${this.user}`);
-        } catch {
+      try { 
+        response = await axios.get(`/users/name/${this.user}`);
+      } catch {
           this.$router.push('/404');
           return;
-        }
+      }
       
         this.idOther = response.data.id;
         const newUser: UserDto = response.data;


### PR DESCRIPTION
So, a little fix to recreate a route which has probably been lost in merges.
To test if everything works: 
- go to a user with this path: `localhost:8000/profile/username`
  - if the user exists, everything will be fine, you'll be on their profile;
  - if not, you'll be on a 404

Don't hesitate to check the code, I am not an expert in back, I may have made some mistakes.